### PR TITLE
feature: add file detection for pretranspiled sass, less, scss files

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,25 @@
-import { promises as fs, utimes, open, close } from 'fs'
+import { close, open, promises as fs, utimes } from 'fs'
+
+async function fileExists(path: string) {
+  try {
+    const stats = await fs.stat(path)
+    return stats.isFile()
+  }
+  catch (e) {
+    return false
+  }
+}
 
 export async function touch(path: string, mode: 'utime' | 'insert-comment' = 'utime') {
-  if (mode === 'utime')
-    return await touchUtime(path)
-  else
-    return await touchInsert(path)
+  path = path.replace(/.[^.]+$/, '.');
+  ['css', 'less', 'sass', 'scss'].forEach(async(ext) => {
+    if (await fileExists(path + ext)) {
+      if (mode === 'utime')
+        return await touchUtime(path + ext)
+      else
+        return await touchInsert(path + ext)
+    }
+  })
 }
 
 const TOUCH_REG = /\/\*\s*windicss-touch:.*\*\//


### PR DESCRIPTION
If we use Less, Scss or Sass, then there may not be a CSS file. Using the extension recognition, it is possible to touch the relevant style file that contains `@windicss`.